### PR TITLE
fix Cannot resolve scoped service Microsoft.Extensions.Options.IOptio…

### DIFF
--- a/src/OrleansCassandraUtils/Persistence/CassandraStorageProvider.cs
+++ b/src/OrleansCassandraUtils/Persistence/CassandraStorageProvider.cs
@@ -20,8 +20,8 @@ namespace OrleansCassandraUtils.Persistence
     {
         public static IGrainStorage Create(IServiceProvider services, string name)
         {
-            IOptionsSnapshot<CassandraGrainStorageOptions> optionsSnapshot = services.GetRequiredService<IOptionsSnapshot<CassandraGrainStorageOptions>>();
-            return ActivatorUtilities.CreateInstance<CassandraGrainStorage>(services, Options.Create(optionsSnapshot.Get(name)), name);
+            IOptionsMonitor<CassandraGrainStorageOptions> optionsMonitor = services.GetRequiredService<IOptionsMonitor<CassandraGrainStorageOptions>>();
+            return ActivatorUtilities.CreateInstance<CassandraGrainStorage>(services, Options.Create(optionsMonitor.Get(name)), name);
         }
     }
 


### PR DESCRIPTION
Issue: 
> System.InvalidOperationException: Cannot resolve scoped service 'Microsoft.Extensions.Options.IOptionsSnapshot`1[OrleansCassandraUtils.Persistence.CassandraGrainStorageOptions]' from root provider.

Related with: https://github.com/dotnet/orleans/issues/5543 

Fix: change IOptionsSnapshot to IOptionsMonitor
